### PR TITLE
Using 'expect' instead of 'when' in second functional test

### DIFF
--- a/test/functional/MovieFunctionalSpec.groovy
+++ b/test/functional/MovieFunctionalSpec.groovy
@@ -15,11 +15,11 @@ class MovieFunctionalSpec extends GebReportingSpec {
 		}
 	}
 	
-	def "when the user opens movie list page it should show a list with 5 or more titles"(){
-		when:
+	def "when the user is at movie list page it should show a list with 5 or more titles"(){
+		expect:
 		at MoviePage
 		
-		then:
+		and:
 		waitFor("slow"){
 			movieList.size() >= 5
 		}


### PR DESCRIPTION
Just the modification you suggested when we were showing the functional tests to Ninjas